### PR TITLE
Use minimial file repository by Mathias Bynens as example files for MIME sniffing

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -1,0 +1,6 @@
+© 2013 The Knights Who Say NIH
+All rights reserved.
+
+By accessing this repository you agree to not disclose documentation, code,
+software, trade secrets, copyrights and other intellectual property interests
+found in the contents of this repository.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "nih-mimesniff",
+  "version": "0.0.1",
+  "author": "Yolijn <yolijn@frameless.io>",
+  "description": "[WIP] Implementation of MIME Sniffing, the Living Standard.",
+  "homepage": "https://wesaynih.com/package/nih-mimesniff",
+  "maintainers": [
+    {
+      "name": "The Knights Who Say NIH!",
+      "url": "https://wesaynih.com/"
+    }
+  ],
+  "contributors": [
+    {
+      "name": "Yolijn",
+      "url": "http://yolijn.com/"
+    },
+    {
+      "name": "Robbert Broersma",
+      "url": "http://robbertbroersma.nl/"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wesaynih/nih-mimesniff"
+  },
+  "bugs": {
+    "url": "https://github.com/wesaynih/nih-mimesniff/issues"
+  },
+  "keywords": [
+    "mime",
+    "media",
+    "content",
+    "sniffing",
+    "mimesniff",
+    "rfc6838"
+  ],
+  "license": "SEE LICENSE IN license.txt",
+  "private": true,
+  "engines": {
+    "node": ">=4.2.0"
+  },
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/package.json
+++ b/package.json
@@ -41,5 +41,7 @@
     "node": ">=4.2.0"
   },
   "dependencies": {},
-  "devDependencies": {}
+  "devDependencies": {
+    "minimal-file": "git://github.com/robbert/minimal-file.git"
+  }
 }


### PR DESCRIPTION
I've added a `package.json` and the required "copyright" license in order to be able to automatically download the set of minimal files using `npm install`. Since the original repository doens't have a `package.json` (which is required to be in `devDependencies`) I've forked the repository and added it myself. I should send a pull request to Mathias.
